### PR TITLE
adding withCheck directive

### DIFF
--- a/src/main/scala/io/github/gatling/cql/CqlAttributes.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlAttributes.scala
@@ -24,5 +24,5 @@ package io.github.gatling.cql
 
 import com.datastax.driver.core.ConsistencyLevel
 
-case class CqlAttributes(tag: String, statement: CqlStatement, cl:ConsistencyLevel = ConsistencyLevel.ONE, checks: List[CheckResult] = List.empty[CheckResult])
+case class CqlAttributes(tag: String, statement: CqlStatement, cl:ConsistencyLevel = ConsistencyLevel.ONE, checks: List[CqlCheck] = List.empty[CqlCheck])
 

--- a/src/main/scala/io/github/gatling/cql/CqlRequestAction.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlRequestAction.scala
@@ -37,17 +37,17 @@ object CqlRequestAction {
   lazy val executor = Executors.newCachedThreadPool()
 }
 
-class CqlRequestAction(val next: ActorRef, protocol: CqlProtocol, attr: CqlAttributes) 
-  extends Interruptable 
+class CqlRequestAction(val next: ActorRef, protocol: CqlProtocol, attr: CqlAttributes)
+  extends Interruptable
   with Failable {
 
   def executeOrFail(session: Session): Validation[Unit] = {
     val start = nowMillis
     val stmt = attr.statement(session)
-    stmt.map{ stmt => 
+    stmt.map{ stmt =>
       stmt.setConsistencyLevel(attr.cl)
       val result = protocol.session.executeAsync(stmt)
-      Futures.addCallback(result, new CqlResponseHandler(next, session, start, attr.tag, stmt), CqlRequestAction.executor)
+      Futures.addCallback(result, new CqlResponseHandler(next, session, start, attr.tag, stmt, attr.checks), CqlRequestAction.executor)
     }
   }
 }

--- a/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
@@ -25,6 +25,7 @@ package io.github.gatling.cql
 import com.datastax.driver.core.PreparedStatement
 import com.datastax.driver.core.SimpleStatement
 import com.datastax.driver.core.ConsistencyLevel
+import com.datastax.driver.core.ResultSet
 
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.Expression
@@ -33,7 +34,7 @@ import io.gatling.core.session.Expression
 case class CqlRequestBuilderBase(tag: String) {
   def execute(statement: Expression[String]) = new CqlRequestBuilder(CqlAttributes(tag, SimpleCqlStatement(statement)))
   def execute(prepared: PreparedStatement) = new CqlRequestParamsBuilder(tag, prepared)
-}  
+}
 
 case class CqlRequestParamsBuilder(tag: String, prepared: PreparedStatement) {
   def withParams(params: Expression[AnyRef]*) = new CqlRequestBuilder(CqlAttributes(tag, BoundCqlStatement(prepared, params:_*)))
@@ -41,5 +42,6 @@ case class CqlRequestParamsBuilder(tag: String, prepared: PreparedStatement) {
 
 case class CqlRequestBuilder(attr: CqlAttributes) {
     def consistencyLevel(level: ConsistencyLevel) = CqlRequestBuilder(attr.copy(cl= level))
+    def withCheck(check: CheckResult) = CqlRequestBuilder(attr.copy(checks = check :: attr.checks))
     def build(): ActionBuilder = new CqlRequestActionBuilder(attr)
 }

--- a/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
@@ -42,6 +42,6 @@ case class CqlRequestParamsBuilder(tag: String, prepared: PreparedStatement) {
 
 case class CqlRequestBuilder(attr: CqlAttributes) {
     def consistencyLevel(level: ConsistencyLevel) = CqlRequestBuilder(attr.copy(cl= level))
-    def withCheck(check: CheckResult) = CqlRequestBuilder(attr.copy(checks = check :: attr.checks))
+    def withCheck(check: CqlCheck) = CqlRequestBuilder(attr.copy(checks = check :: attr.checks))
     def build(): ActionBuilder = new CqlRequestActionBuilder(attr)
 }

--- a/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
@@ -42,6 +42,6 @@ case class CqlRequestParamsBuilder(tag: String, prepared: PreparedStatement) {
 
 case class CqlRequestBuilder(attr: CqlAttributes) {
     def consistencyLevel(level: ConsistencyLevel) = CqlRequestBuilder(attr.copy(cl= level))
-    def withCheck(check: CqlCheck) = CqlRequestBuilder(attr.copy(checks = check :: attr.checks))
+    def check(check: CqlCheck) = CqlRequestBuilder(attr.copy(checks = check :: attr.checks))
     def build(): ActionBuilder = new CqlRequestActionBuilder(attr)
 }

--- a/src/main/scala/io/github/gatling/cql/CqlResponseHandler.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlResponseHandler.scala
@@ -42,11 +42,12 @@ class CqlResponseHandler(next: ActorRef, session: Session, start: Long, tag: Str
   private def writeData(status: Status, message: Option[String]) = writeRequestData(session, tag, start, nowMillis, session.startDate, nowMillis, status, message, Nil)
 
   def onSuccess(result: ResultSet) = {
-    val checkResults: List[String] = checks.flatMap { f => f(result) match {
-                                            case Success(_) => None
-                                            case Failure(msg) => Some(msg)
-                                          }
-                                        }
+    val checkResults: List[String] = checks.flatMap { check =>
+      check(result) match {
+        case Failure(msg) => Some(msg)
+        case _ => None
+      }
+    }
     checkResults match {
       case Nil =>
         writeData(OK, None)

--- a/src/main/scala/io/github/gatling/cql/CqlResponseHandler.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlResponseHandler.scala
@@ -34,7 +34,7 @@ import io.gatling.core.util.TimeHelper.nowMillis
 import io.gatling.core.validation._
 import com.typesafe.scalalogging.StrictLogging
 
-class CqlResponseHandler(next: ActorRef, session: Session, start: Long, tag: String, stmt: Statement, checks: List[CheckResult])
+class CqlResponseHandler(next: ActorRef, session: Session, start: Long, tag: String, stmt: Statement, checks: List[CqlCheck])
   extends FutureCallback[ResultSet]
   with DataWriterClient
   with StrictLogging {

--- a/src/main/scala/io/github/gatling/cql/package.scala
+++ b/src/main/scala/io/github/gatling/cql/package.scala
@@ -20,9 +20,11 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package io.github.gatling.cql
 
-import com.datastax.driver.core.ConsistencyLevel
+package io.github.gatling
 
-case class CqlAttributes(tag: String, statement: CqlStatement, cl:ConsistencyLevel = ConsistencyLevel.ONE, checks: List[CheckResult] = List.empty[CheckResult])
+import com.datastax.driver.core.ResultSet
 
+package object cql {
+  type CheckResult = ResultSet => Option[String]
+}

--- a/src/main/scala/io/github/gatling/cql/package.scala
+++ b/src/main/scala/io/github/gatling/cql/package.scala
@@ -23,8 +23,9 @@
 
 package io.github.gatling
 
+import io.gatling.core.validation.Validation
 import com.datastax.driver.core.ResultSet
 
 package object cql {
-  type CheckResult = ResultSet => Option[String]
+  type CheckResult = ResultSet => Validation[Boolean]
 }

--- a/src/main/scala/io/github/gatling/cql/package.scala
+++ b/src/main/scala/io/github/gatling/cql/package.scala
@@ -27,5 +27,5 @@ import io.gatling.core.validation.Validation
 import com.datastax.driver.core.ResultSet
 
 package object cql {
-  type CheckResult = ResultSet => Validation[Boolean]
+  type CqlCheck = ResultSet => Validation[Boolean]
 }

--- a/src/test/scala/io/github/gatling/cql/CqlRequestActionSpec.scala
+++ b/src/test/scala/io/github/gatling/cql/CqlRequestActionSpec.scala
@@ -52,7 +52,7 @@ class CqlRequestActionSpec extends FlatSpec with EasyMockSugar with Matchers wit
   val target = TestActorRef(
     new CqlRequestAction(ActorRef.noSender,
       CqlProtocol(cassandraSession),
-      CqlAttributes("test", statement, ConsistencyLevel.ANY, List.empty[CheckResult]))).underlyingActor
+      CqlAttributes("test", statement, ConsistencyLevel.ANY, List.empty[CqlCheck]))).underlyingActor
 
   before {
     reset(statement, cassandraSession)

--- a/src/test/scala/io/github/gatling/cql/CqlRequestActionSpec.scala
+++ b/src/test/scala/io/github/gatling/cql/CqlRequestActionSpec.scala
@@ -52,7 +52,7 @@ class CqlRequestActionSpec extends FlatSpec with EasyMockSugar with Matchers wit
   val target = TestActorRef(
     new CqlRequestAction(ActorRef.noSender,
       CqlProtocol(cassandraSession),
-      CqlAttributes("test", statement, ConsistencyLevel.ANY))).underlyingActor
+      CqlAttributes("test", statement, ConsistencyLevel.ANY, List.empty[CheckResult]))).underlyingActor
 
   before {
     reset(statement, cassandraSession)


### PR DESCRIPTION
A new method _withCheck(CheckResult)_ has been added. This method takes in as parameter a function from com.datastax.driver.core.ResultSet => Option[String]. The function should return a String describing the error of the check, None if no error has been encountered.

The list of checks is added to CqlAttributes, and it is executed against the resultSet as obtained in the CqlResponseHandler. If multiple checks fail, their results are all reported.

No tests have been added at this time, but I have tested it in a scenario forcing the failure. 